### PR TITLE
OIDC provider uses https now

### DIFF
--- a/LAPPS-backend/src/main/java/de/rwth/dbis/layers/lapps/authenticate/OIDCAuthentication.java
+++ b/LAPPS-backend/src/main/java/de/rwth/dbis/layers/lapps/authenticate/OIDCAuthentication.java
@@ -31,7 +31,7 @@ import de.rwth.dbis.layers.lapps.exception.OIDCException;
 @Singleton
 public class OIDCAuthentication {
 
-  private static final String OPEN_ID_PROVIDER = "http://api.learning-layers.eu/o/oauth2";
+  private static final String OPEN_ID_PROVIDER = "https://api.learning-layers.eu/o/oauth2";
   private static final String OPEN_ID_PROVIDER_CONFIGURATION_URI = OPEN_ID_PROVIDER.trim()
       + "/.well-known/openid-configuration";
 


### PR DESCRIPTION
small address change (Since old provider address was discarded)
